### PR TITLE
Updated the scheduled job to include a check for empty content reference...

### DIFF
--- a/TagsScheduledJob.cs
+++ b/TagsScheduledJob.cs
@@ -14,8 +14,6 @@ using Geta.Tags.Helpers;
 
 namespace Geta.Tags
 {
-    using System.Web.UI.WebControls;
-
     [ScheduledPlugIn(DisplayName = "Geta Tags maintenance", DefaultEnabled = true)]
     public class TagsScheduledJob : JobBase
     {


### PR DESCRIPTION
There was an error in the scheduled job when the GetContentReference returned an empty reference. I just added a is null or empty check to fix it.
