### PR TITLE
Fix: Problem when adding multiple word tags. 

### DIFF
--- a/TagsModule.cs
+++ b/TagsModule.cs
@@ -40,7 +40,7 @@ namespace Geta.Tags
             var tagNames = page[propertyDefinition.Name] as string;
             return tagNames == null
                 ? Enumerable.Empty<string>()
-                : tagNames.Split(new[] {',', ' '}, StringSplitOptions.RemoveEmptyEntries);
+                : tagNames.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public void Initialize(InitializationEngine context)


### PR DESCRIPTION
If I tried to add a tag with several words, they would be saved as seperate words even if I use " ". 
But with this fix everything works fine. 
