### PR TITLE
Modified property widget so it reacts to value changes

### DIFF
--- a/src/ClientResources/Geta.Tags/TagsSelection.js
+++ b/src/ClientResources/Geta.Tags/TagsSelection.js
@@ -1,19 +1,41 @@
 ﻿define([
     "dojo/_base/declare",
-    "dijit/form/TextBox",
+    "dijit/form/TextBox"
 ],
 function (
     declare,
-    TextBox) {
-
+    TextBox
+) {
     return declare([TextBox], {
+
+        _tagWidget: null,
+
         postCreate: function () {
-            var $domNode = $(this.domNode),
-                isReadonly = $domNode.hasClass('dijitReadOnly');
-            $domNode.find('input').tagit({
+            this.inherited(arguments);
+            this._createTags();
+        },
+
+        destroy: function() {
+            this._destroyTags();
+            this.inherited(arguments);
+        },
+
+        _createTags: function () {
+            this._destroyTags();
+            this._tagWidget = $(this.textbox).tagit({
                 autocomplete: { delay: 0, minLength: 2, source: '/getatags?groupKey=' + this.groupKey },
-                readOnly: isReadonly
+                readOnly: this.readOnly
             });
+        },
+
+        _destroyTags: function() {
+            this._tagWidget && this._tagWidget.tagit("destroy");
+            this._tagWidget = null;
+        },
+
+        _setValueAttr: function (value, priorityChange) {
+            this.inherited(arguments);
+            this._started && !priorityChange && this._createTags();
         }
     });
 });

--- a/src/ClientResources/Geta.Tags/styles/tagit.ui-zendesk.css
+++ b/src/ClientResources/Geta.Tags/styles/tagit.ui-zendesk.css
@@ -7,6 +7,7 @@ ul.tagit {
     border-width: 1px;
     border-color: #C6C6C6;
     background: inherit;
+    padding: 0;
 }
 ul.tagit li.tagit-choice {
     -moz-border-radius: 6px;


### PR DESCRIPTION
The TagIt widget only read values when created so in order to work when the value
changes it needs to be recreated. Also made sure the base implementation gets
called on infrastructure methods and cleanup is performed when destroyed.

Fixes: #29