### PR TITLE
Bugfix/case sensitive fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ IEnumerable<ContentReference> GetContentReferencesByTags(IEnumerable<Tag> tags);
 IEnumerable<ContentReference> GetContentReferencesByTags(string tagNames, ContentReference rootContentReference);
 IEnumerable<ContentReference> GetContentReferencesByTags(IEnumerable<Tag> tags, ContentReference rootContentReference);
 ```
+
+##Customize Tag-it behaviour
+You can customize the [Tag-it.js](https://github.com/aehlke/tag-it) settings by using the GetaTagsAttribute.
+The following settings can currently be customized
+* allowSpaces - defaults to **false**
+* allowDuplicates - defaults to **false**
+* caseSensitive - defaults to **true**
+```csharp
+[CultureSpecific]
+[UIHint("Tags")]
+[GetaTags(AllowSpaces = true, AllowDuplicates = true, CaseSensitive = false)]
+public virtual string Tags { get; set; }

--- a/src/EditorDescriptors/GetaTagsAttribute.cs
+++ b/src/EditorDescriptors/GetaTagsAttribute.cs
@@ -15,6 +15,13 @@ namespace Geta.Tags.EditorDescriptors
         public bool CaseSensitive { get; set; }
         public bool AllowDuplicates { get; set; }
 
+        public GetaTagsAttribute() {
+            AllowDuplicates = false;
+            AllowSpaces = false;
+            CaseSensitive = true;
+
+        }
+
         public virtual void OnMetadataCreated(ModelMetadata metadata)
         {
             var extendedMetadata = metadata as ExtendedMetadata;

--- a/src/EditorDescriptors/GetaTagsAttribute.cs
+++ b/src/EditorDescriptors/GetaTagsAttribute.cs
@@ -19,7 +19,6 @@ namespace Geta.Tags.EditorDescriptors
             AllowDuplicates = false;
             AllowSpaces = false;
             CaseSensitive = true;
-
         }
 
         public virtual void OnMetadataCreated(ModelMetadata metadata)

--- a/src/EditorDescriptors/TagsEditorDescriptor.cs
+++ b/src/EditorDescriptors/TagsEditorDescriptor.cs
@@ -21,10 +21,12 @@ namespace Geta.Tags.EditorDescriptors
             base.ModifyMetadata(metadata, attributes);
             var groupKeyAttribute = attributes.FirstOrDefault(a => typeof (TagsGroupKeyAttribute) == a.GetType()) as TagsGroupKeyAttribute;
             var cultureSpecificAttribute = attributes.FirstOrDefault(a => typeof(CultureSpecificAttribute) == a.GetType()) as CultureSpecificAttribute;
+            var getaAttribute = attributes.FirstOrDefault(a => typeof(GetaTagsAttribute) == a.GetType()) as GetaTagsAttribute;
+
             metadata.EditorConfiguration["GroupKey"] = Helpers.TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute);
-            metadata.EditorConfiguration["allowSpaces"] = false;
-            metadata.EditorConfiguration["allowDuplicates"] = false;
-            metadata.EditorConfiguration["caseSensitive"] = true;
+            metadata.EditorConfiguration["allowSpaces"] = getaAttribute != null ? getaAttribute.AllowSpaces : false;
+            metadata.EditorConfiguration["allowDuplicates"] = getaAttribute != null ? getaAttribute.AllowDuplicates : false;
+            metadata.EditorConfiguration["caseSensitive"] = getaAttribute != null ? getaAttribute.CaseSensitive : true;
         }
     }
 }


### PR DESCRIPTION
The CaseSensitive attribute was ignored, it didn't matter what I set it to with my attribute, this fix makes sure that the attribute will be used, if no attribute it will fallback to default values. 
Don't know how I missed that one... :)

Output when having no GetaTagsAttribute on property(uses default values)
<img width="128" alt="no-attribute-default-values" src="https://cloud.githubusercontent.com/assets/1232096/14980510/652cd1b6-1129-11e6-87cd-edc2c8047ed4.png">

Output when only specifying AllowSpaces = true on GetaTagsAttribute(using default values for allowDuplicates and caseSensitive)
<img width="135" alt="attribute-allow-spaces-specified" src="https://cloud.githubusercontent.com/assets/1232096/14980546/a6d782a0-1129-11e6-80b2-c7d976f52a57.png">

Output when all properties set to false on GetaTagsAttribute
<img width="131" alt="attribute-all-false" src="https://cloud.githubusercontent.com/assets/1232096/14980597/e2f15fd6-1129-11e6-918d-766436ff1357.png">

Output when all properties set to true on GetaTagsAttribute
<img width="128" alt="attribute-all-true" src="https://cloud.githubusercontent.com/assets/1232096/14980627/18c79526-112a-11e6-8a09-be68a3d98e63.png">
