### PR TITLE
Change geta-tags.TagsSelection to geta-tags/TagsSelection, as Episerver 10 no longer supports it

### DIFF
--- a/src/EditorDescriptors/GetaTagsAttribute.cs
+++ b/src/EditorDescriptors/GetaTagsAttribute.cs
@@ -36,7 +36,7 @@ namespace Geta.Tags.EditorDescriptors
             var groupKeyAttribute = extendedMetadata.Attributes.FirstOrDefault(a => typeof(TagsGroupKeyAttribute) == a.GetType()) as TagsGroupKeyAttribute;
             var cultureSpecificAttribute = extendedMetadata.Attributes.FirstOrDefault(a => typeof(CultureSpecificAttribute) == a.GetType()) as CultureSpecificAttribute;
 
-            extendedMetadata.ClientEditingClass = "geta-tags.TagsSelection";
+            extendedMetadata.ClientEditingClass = "geta-tags/TagsSelection";
             extendedMetadata.CustomEditorSettings["uiType"] = extendedMetadata.ClientEditingClass;
             extendedMetadata.CustomEditorSettings["uiWrapperType"] = UiWrapperType.Floating;
             extendedMetadata.EditorConfiguration["GroupKey"] = Helpers.TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute);

--- a/src/EditorDescriptors/TagsEditorDescriptor.cs
+++ b/src/EditorDescriptors/TagsEditorDescriptor.cs
@@ -12,7 +12,7 @@ namespace Geta.Tags.EditorDescriptors
     {
         public TagsEditorDescriptor()
         {
-            ClientEditingClass = "geta-tags.TagsSelection";
+            ClientEditingClass = "geta-tags/TagsSelection";
         }
 
         public override void ModifyMetadata(EPiServer.Shell.ObjectEditing.ExtendedMetadata metadata,


### PR DESCRIPTION
Episerver 10 stopped supporting module paths with dot separator:
http://world.episerver.com/documentation/Release-Notes/ReleaseNote/?releaseNoteId=CMS-2295