### PR TITLE
Feature to restrict number of tags that can be used

### DIFF
--- a/src/ClientResources/TagsSelection.js
+++ b/src/ClientResources/TagsSelection.js
@@ -21,9 +21,6 @@ function (
         },
 
         _createTags: function () {
-
-            console.log('this.tagLimit', this.tagLimit);
-
             this._destroyTags();
             this._tagWidget = $(this.textbox).tagit({
                 autocomplete: { delay: 0, minLength: 2, source: '/getatags?groupKey=' + this.groupKey },

--- a/src/ClientResources/TagsSelection.js
+++ b/src/ClientResources/TagsSelection.js
@@ -21,6 +21,9 @@ function (
         },
 
         _createTags: function () {
+
+            console.log('this.tagLimit', this.tagLimit);
+
             this._destroyTags();
             this._tagWidget = $(this.textbox).tagit({
                 autocomplete: { delay: 0, minLength: 2, source: '/getatags?groupKey=' + this.groupKey },
@@ -28,6 +31,7 @@ function (
                 allowDuplicates: this.allowDuplicates,
                 caseSensitive: this.caseSensitive,
                 readOnly: this.readOnly,
+                tagLimit: this.tagLimit !== -1 ? this.tagLimit : null,
                 beforeTagAdded: function () {
                     this.onFocus();
                 }.bind(this),

--- a/src/EditorDescriptors/GetaTagsAttribute.cs
+++ b/src/EditorDescriptors/GetaTagsAttribute.cs
@@ -14,6 +14,7 @@ namespace Geta.Tags.EditorDescriptors
         public bool AllowSpaces { get; set; }
         public bool CaseSensitive { get; set; }
         public bool AllowDuplicates { get; set; }
+        public int TagLimit { get; set; }
 
         public bool ReadOnly { get; set; }
 
@@ -22,6 +23,7 @@ namespace Geta.Tags.EditorDescriptors
             AllowSpaces = false;
             CaseSensitive = true;
             ReadOnly = false;
+            TagLimit = -1;
         }
 
         public virtual void OnMetadataCreated(ModelMetadata metadata)
@@ -44,6 +46,7 @@ namespace Geta.Tags.EditorDescriptors
             extendedMetadata.EditorConfiguration["allowDuplicates"] = this.AllowDuplicates;
             extendedMetadata.EditorConfiguration["caseSensitive "] = this.CaseSensitive;
             extendedMetadata.EditorConfiguration["readOnly "] = this.ReadOnly;
+            extendedMetadata.EditorConfiguration["tagLimit"] = this.TagLimit;
         }
     }
 }


### PR DESCRIPTION
This feature uses the Tag-It [tagLimit ](https://github.com/aehlke/tag-it/blob/master/README.markdown#user-content-taglimit-integer)to restrict how many tags can be used.