### PR TITLE
I have 2 fix, finding attributes with UIHint tags and edit a tag with no grub key, will create 2 tags with same name

### DIFF
--- a/src/Controllers/GetaTagsAdminController.cs
+++ b/src/Controllers/GetaTagsAdminController.cs
@@ -101,7 +101,6 @@ namespace Geta.Tags.Controllers
 
             existingTag.Name = eddittedTag.Name;
             existingTag.GroupKey = eddittedTag.GroupKey;
-
             _tagRepository.Save(existingTag);
 
             return RedirectToAction("Index", new { page, searchString });
@@ -118,10 +117,10 @@ namespace Geta.Tags.Controllers
 
                 var clone = pageFromRepository.CreateWritableClone();
 
-                 var tagAttributes = clone.GetType().GetProperties().Where(
-                    prop => Attribute.IsDefined(prop, typeof(UIHintAttribute)) &&
-                    prop.PropertyType == typeof(string) &&
-                    Attribute.GetCustomAttributes(prop, typeof(UIHintAttribute)).Any(x=> ((UIHintAttribute)x).Equals("Tags")));
+                var tagAttributes = clone.GetType().GetProperties().Where(
+                   prop => Attribute.IsDefined(prop, typeof(UIHintAttribute)) &&
+                   prop.PropertyType == typeof(string) &&
+                   Attribute.GetCustomAttributes(prop, typeof(UIHintAttribute)).Any(x => ((UIHintAttribute)x).UIHint == "Tags"));
 
                 foreach (var tagAttribute in tagAttributes)
                 {

--- a/src/Implementations/TagRepository.cs
+++ b/src/Implementations/TagRepository.cs
@@ -29,7 +29,7 @@ namespace Geta.Tags.Implementations
             return TagStore
                 .Find<Tag>(new Dictionary<string, object>
                 {
-                    { "Name", name }, { "GroupKey", groupKey }
+                    { "Name", name }, { "GroupKey", groupKey ?? string.Empty }
                 })
                 .FirstOrDefault();
         }


### PR DESCRIPTION
Fix: If no grub key it will create 2 tags in the manager interface with same name
Fix: finding UIHintAttribute with UIHInt == Tags