### PR TITLE
Fix #70

### DIFF
--- a/src/EditorDescriptors/GetaTagsAttribute.cs
+++ b/src/EditorDescriptors/GetaTagsAttribute.cs
@@ -38,7 +38,6 @@ namespace Geta.Tags.EditorDescriptors
                 return;
             }
 
-
             var groupKeyAttribute = extendedMetadata
                 .Attributes
                 .FirstOrDefault(a => typeof(TagsGroupKeyAttribute) == a.GetType()) as TagsGroupKeyAttribute;

--- a/src/EditorDescriptors/GetaTagsAttribute.cs
+++ b/src/EditorDescriptors/GetaTagsAttribute.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Web.Mvc;
+﻿using EPiServer.Cms.Shell.Extensions;
 using EPiServer.DataAnnotations;
 using EPiServer.Shell;
 using EPiServer.Shell.ObjectEditing;
 using Geta.Tags.Attributes;
+using Geta.Tags.Helpers;
+using System;
+using System.Linq;
+using System.Web.Mvc;
 
 namespace Geta.Tags.EditorDescriptors
 {
@@ -18,7 +20,8 @@ namespace Geta.Tags.EditorDescriptors
 
         public bool ReadOnly { get; set; }
 
-        public GetaTagsAttribute() {
+        public GetaTagsAttribute()
+        {
             AllowDuplicates = false;
             AllowSpaces = false;
             CaseSensitive = true;
@@ -35,18 +38,20 @@ namespace Geta.Tags.EditorDescriptors
                 return;
             }
 
+
             var groupKeyAttribute = extendedMetadata
                 .Attributes
                 .FirstOrDefault(a => typeof(TagsGroupKeyAttribute) == a.GetType()) as TagsGroupKeyAttribute;
             var cultureSpecificAttribute = extendedMetadata
                 .Attributes
                 .FirstOrDefault(a => typeof(CultureSpecificAttribute) == a.GetType()) as CultureSpecificAttribute;
+            var ownerContent = extendedMetadata.FindOwnerContent();
 
             extendedMetadata.ClientEditingClass = "geta-tags/TagsSelection";
             extendedMetadata.CustomEditorSettings["uiType"] = extendedMetadata.ClientEditingClass;
             extendedMetadata.CustomEditorSettings["uiWrapperType"] = UiWrapperType.Floating;
             extendedMetadata.EditorConfiguration["GroupKey"] =
-                Helpers.TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute);
+                TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute, ownerContent);
             extendedMetadata.EditorConfiguration["allowSpaces"] = AllowSpaces;
             extendedMetadata.EditorConfiguration["allowDuplicates"] = AllowDuplicates;
             extendedMetadata.EditorConfiguration["caseSensitive "] = CaseSensitive;

--- a/src/EditorDescriptors/TagsEditorDescriptor.cs
+++ b/src/EditorDescriptors/TagsEditorDescriptor.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using EPiServer.Cms.Shell.Extensions;
 using EPiServer.DataAnnotations;
+using EPiServer.Shell.ObjectEditing;
 using EPiServer.Shell.ObjectEditing.EditorDescriptors;
 using Geta.Tags.Attributes;
+using Geta.Tags.Helpers;
 
 namespace Geta.Tags.EditorDescriptors
 {
@@ -15,7 +18,7 @@ namespace Geta.Tags.EditorDescriptors
             ClientEditingClass = "geta-tags/TagsSelection";
         }
 
-        public override void ModifyMetadata(EPiServer.Shell.ObjectEditing.ExtendedMetadata metadata,
+        public override void ModifyMetadata(ExtendedMetadata metadata,
             IEnumerable<Attribute> attributes)
         {
             var attrs = attributes.ToArray();
@@ -26,9 +29,10 @@ namespace Geta.Tags.EditorDescriptors
                 a => typeof(CultureSpecificAttribute) == a.GetType()) as CultureSpecificAttribute;
             var getaAttribute = attrs.FirstOrDefault(
                 a => typeof(GetaTagsAttribute) == a.GetType()) as GetaTagsAttribute;
+            var ownerContent = metadata.FindOwnerContent();
 
             metadata.EditorConfiguration["GroupKey"] =
-                Helpers.TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute);
+                TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute, ownerContent);
             metadata.EditorConfiguration["allowSpaces"] = getaAttribute?.AllowSpaces ?? false;
             metadata.EditorConfiguration["allowDuplicates"] = getaAttribute?.AllowDuplicates ?? false;
             metadata.EditorConfiguration["readOnly"] = getaAttribute?.ReadOnly ?? false;

--- a/src/Helpers/TagsHelper.cs
+++ b/src/Helpers/TagsHelper.cs
@@ -41,8 +41,7 @@ namespace Geta.Tags.Helpers
 
         public static bool IsTagProperty(PropertyDefinition propertyDefinition)
         {
-            return propertyDefinition != null && 
-                   propertyDefinition.TemplateHint == "Tags";
+            return propertyDefinition != null && propertyDefinition.TemplateHint == "Tags";
         }
     }
 }

--- a/src/Helpers/TagsHelper.cs
+++ b/src/Helpers/TagsHelper.cs
@@ -1,20 +1,25 @@
-﻿using System;
-using System.Globalization;
-using EPiServer.Core;
+﻿using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.DataAnnotations;
 using EPiServer.Globalization;
 using EPiServer.Web;
 using Geta.Tags.Attributes;
+using System;
+using System.Globalization;
 
 namespace Geta.Tags.Helpers
 {
     public static class TagsHelper
     {
         public static string GetGroupKeyFromAttributes(
-            TagsGroupKeyAttribute groupKeyAttribute, CultureSpecificAttribute cultureSpecificAttribute)
+            TagsGroupKeyAttribute groupKeyAttribute, CultureSpecificAttribute cultureSpecificAttribute, IContent content)
         {
             var groupKey = string.Empty;
+
+            if (groupKeyAttribute == null && cultureSpecificAttribute == null && content is ILocalizable localizableContent)
+            {
+                groupKey += localizableContent.MasterLanguage;
+            }
 
             if (groupKeyAttribute != null)
             {
@@ -36,8 +41,8 @@ namespace Geta.Tags.Helpers
 
         public static bool IsTagProperty(PropertyDefinition propertyDefinition)
         {
-            return propertyDefinition != null
-                   && propertyDefinition.TemplateHint == "Tags";
+            return propertyDefinition != null && 
+                   propertyDefinition.TemplateHint == "Tags";
         }
     }
 }

--- a/src/Helpers/TagsHelper.cs
+++ b/src/Helpers/TagsHelper.cs
@@ -41,7 +41,8 @@ namespace Geta.Tags.Helpers
 
         public static bool IsTagProperty(PropertyDefinition propertyDefinition)
         {
-            return propertyDefinition != null && propertyDefinition.TemplateHint == "Tags";
+            return propertyDefinition != null 
+                   && propertyDefinition.TemplateHint == "Tags";
         }
     }
 }

--- a/src/TagsModule.cs
+++ b/src/TagsModule.cs
@@ -53,7 +53,7 @@ namespace Geta.Tags
                 var cultureSpecificAttribute
                     = tagPropertyInfo.GetCustomAttribute(typeof(CultureSpecificAttribute)) as CultureSpecificAttribute;
 
-                var groupKey = TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute);
+                var groupKey = TagsHelper.GetGroupKeyFromAttributes(groupKeyAttribute, cultureSpecificAttribute, content);
 
                 _tagService.Save(content.ContentGuid, tags, groupKey);
             }


### PR DESCRIPTION
Now, all localizable content should have the group key set (populated with master language code), without TagsGroupKeyAttribute or CultureSpecificAttribute specified