### PR TITLE
Feature/skip validation

### DIFF
--- a/src/Controllers/GetaTagsAdminController.cs
+++ b/src/Controllers/GetaTagsAdminController.cs
@@ -151,7 +151,7 @@ namespace Geta.Tags.Controllers
 
                     tagAttribute.SetValue(clone, tagsCommaSeperated);
                 }
-                _contentRepository.Save((IContent)clone, SaveAction.Publish, AccessLevel.NoAccess);
+                _contentRepository.Save((IContent)clone, SaveAction.Publish | SaveAction.SkipValidation, AccessLevel.NoAccess);
             }
             _tagRepository.Delete(tagFromTagRepository);
         }


### PR DESCRIPTION
Skip validation when saving an IContent item.
This significantly speeds up saving a lot of items and skips any validation issues that cannot be handled from the admin interface.